### PR TITLE
Update terminal title after changing directory

### DIFF
--- a/terminal-title.elv
+++ b/terminal-title.elv
@@ -30,6 +30,9 @@ fn init {
   prompt-hooks:add-after-readline {|cmd|
     set-title ($title-during-command $cmd)
   }
+  set after-chdir = [ $@after-chdir {|dir|
+    set-title ($title-during-prompt)
+  } ]
 }
 
 init

--- a/terminal-title.org
+++ b/terminal-title.org
@@ -93,7 +93,7 @@ The =$terminal-title:title-during-prompt= and =$terminal-title:title-during-comm
 <<title-during-command-default>>
 #+end_src
 
-The =init= function sets up the corresponding prompt hooks.
+The =init= function sets up the corresponding prompt hooks and after-chdir hook. The after-chdir hook is needed for cases such as navigating with the built-in Elvish location and navigation modes.
 
 #+begin_src elvish
   fn init {
@@ -103,6 +103,9 @@ The =init= function sets up the corresponding prompt hooks.
     prompt-hooks:add-after-readline {|cmd|
       set-title ($title-during-command $cmd)
     }
+    set after-chdir = [ $@after-chdir {|dir|
+      set-title ($title-during-prompt)
+    } ]
   }
 #+end_src
 


### PR DESCRIPTION
The terminal title will be "stale" after changing directory via another mechanism than cd (for example the elvish built-in navigation and location modes). Triggering a new prompt (for example, by pressing return) is needed to update the terminal title.

This change adds an `after-chdir` hook to trigger a terminal title update after these events, since the prompt does not get redrawn (if I understand correctly). 

Note that when changing directories in navigation mode using left/right arrows, the title will be updated live, as you navigate.

Edit: Added a better comment to the org file.