### PR TITLE
Never show long-running notifications for Neovim

### DIFF
--- a/long-running-notifications.elv
+++ b/long-running-notifications.elv
@@ -8,7 +8,7 @@ var notifier = auto
 
 var notifications-to-try = [ macos libnotify text ]
 
-var never-notify = [ vi vim emacs nano less more bat ]
+var never-notify = [ vi vim nvim emacs nano less more bat ]
 var always-notify = [ ]
 
 var notification-fns = [

--- a/long-running-notifications.org
+++ b/long-running-notifications.org
@@ -46,7 +46,7 @@ The default notification threshold is 10 seconds, so when the command finishes, 
 You can specify a list commands for which you do not want notifications in the =$long-running-notifications:never-notify= variable, and a list of commands that should always be notified (regardless of how long they took) in =always-notify=. Their default values are:
 
 #+begin_src  elvish
-  never-notify = [ vi vim emacs nano less more bat ]
+  never-notify = [ vi vim nvim emacs nano less more bat ]
   always-notify = [ ]
 #+end_src
 


### PR DESCRIPTION
Neovim behaves in the same way as Vim, and seems (anecdotally at least) to have a reasonably significant number of users, so I think it warrants inclusion in this list.